### PR TITLE
Modify debug behavior to reverse-proxy all non-matching requests to react debug server.

### DIFF
--- a/fleasite/frontend.py
+++ b/fleasite/frontend.py
@@ -1,0 +1,15 @@
+"""
+This file is a site-level script to reverse-proxy the frontend server. It will only be used in development mode.
+Change the upstream as needed but do not commit the change.
+"""
+from django.views.decorators.csrf import ensure_csrf_cookie
+from revproxy.views import ProxyView
+
+
+class DebugReactProxyView(ProxyView):
+    upstream = "http://localhost:3000/"
+
+
+@ensure_csrf_cookie
+def CSRFedDebugReactProxyView(request, *args, **kwargs):
+    return DebugReactProxyView.as_view()(request, *args, **kwargs)

--- a/fleasite/settings_common.py
+++ b/fleasite/settings_common.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "revproxy",
     "fleaapi",
 ]
 
@@ -117,7 +118,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "pystatic/"
 
 STATIC_ROOT = BASE_DIR / "dist"
 
@@ -170,6 +171,10 @@ LOGGING = {
         "fleasite": {
             "handlers": ["console", "django.server"],
             "level": "INFO",
+        },
+        "revproxy": {
+            "handlers": ["console", "django.server"],
+            "level": "WARNING",
         },
     },
 }

--- a/fleasite/urls.py
+++ b/fleasite/urls.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.shortcuts import render
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.static import serve
 
@@ -41,3 +41,13 @@ urlpatterns = [
     path("checkout.html", checkout_demo_page),  # for test only
     path("return.html", return_demo_page),  # for test only
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+# Debug React proxy
+if settings.DEBUG:
+    from .frontend import CSRFedDebugReactProxyView
+
+    urlpatterns.extend(
+        [
+            re_path(r'^(?P<path>.*)$', CSRFedDebugReactProxyView),
+        ]
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black==23.9.1
 Django==4.1.11
 djangorestframework==3.14.0
+django-revproxy=0.12.0
 pytest==7.4.2
 pytest-cov==4.1.0
 pytest-django==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==23.9.1
 Django==4.1.11
 djangorestframework==3.14.0
-django-revproxy=0.12.0
+django-revproxy==0.12.0
 pytest==7.4.2
 pytest-cov==4.1.0
 pytest-django==4.5.2

--- a/static/checkout.html
+++ b/static/checkout.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- <link rel="stylesheet" href="style.css" /> -->
     <script src="https://js.stripe.com/v3/"></script>
-    <script src="/static/checkout.js" defer></script>
+    <script src="/pystatic/checkout.js" defer></script>
   </head>
   <body>
     <!-- Display a payment form -->

--- a/static/return.html
+++ b/static/return.html
@@ -3,7 +3,7 @@
 <head>
   <title>Thanks for your order!</title>
   <!-- <link rel="stylesheet" href="style.css"> -->
-  <script src="/static/return.js" defer></script>
+  <script src="/pystatic/return.js" defer></script>
 </head>
 <body>
   <section id="success" class="hidden">


### PR DESCRIPTION
As title.
This change should reduce the effort to debugging integration APIs.
Also renames static path on Django from `static/` to `pystatic/` to avoid the conflicts on the static files, where the reverse proxy stops working. 

Note: the react server is hard-coded so devs might need to change the value of `upstream`. Also this code should never run on production, 